### PR TITLE
fix: findByName params handling in data services

### DIFF
--- a/src/app/images-collection/images-collection.service.ts
+++ b/src/app/images-collection/images-collection.service.ts
@@ -7,12 +7,6 @@ import {Image, PaginatedImages} from './image';
 import {MetadataFile, PaginatedMetadataFiles} from './metadata-file';
 import {environment} from '../../environments/environment';
 
-// const httpOptions = {
-//   headers: new HttpHeaders({ 'Content-Type': 'application/json' }),
-//   params: new HttpParams()
-// };
-
-
 @Injectable({
   providedIn: 'root'
 })
@@ -48,12 +42,14 @@ export class ImagesCollectionService {
       headers: new HttpHeaders({ 'Content-Type': 'application/json' }),
       params: {}
     };
-    const page = params.pageIndex ? params.pageIndex : null;
-    const size = params.size ? params.size : null;
-    const sort = params.sort ? params.sort : null;
-    const httpParams = new HttpParams().set('name', name).set('page', page).set('size', size).set('sort', sort);
+    const httpParams = new HttpParams().set('name', name);
+    if (params) {
+      const page = params.pageIndex ? params.pageIndex : null;
+      const size = params.size ? params.size : null;
+      const sort = params.sort ? params.sort : null;
+      httpParams.set('page', page).set('size', size).set('sort', sort);
+    }
     httpOptions.params = httpParams;
-    console.log(httpOptions.params);
     return this.http.get<any>(this.imagesCollectionsUrl + '/search/findByNameContainingIgnoreCase', httpOptions).pipe(
       map((result: any) => {
         result.imagesCollections = result._embedded.imagesCollections;
@@ -66,11 +62,13 @@ export class ImagesCollectionService {
       headers: new HttpHeaders({'Content-Type': 'application/json'}),
       params: {}
     };
-    const page = params.pageIndex ? params.pageIndex : null;
-    const size = params.size ? params.size : null;
-    const sort = params.sort ? params.sort : null;
-    const httpParams = new HttpParams().set('name', name).set('numberOfImages', nbOfImgs)
-      .set('page', page).set('size', size).set('sort', sort);
+    const httpParams = new HttpParams().set('name', name).set('numberOfImages', nbOfImgs);
+    if (params) {
+      const page = params.pageIndex ? params.pageIndex : null;
+      const size = params.size ? params.size : null;
+      const sort = params.sort ? params.sort : null;
+      httpParams.set('page', page).set('size', size).set('sort', sort);
+    }
     httpOptions.params = httpParams;
     return this.http.get<any>(this.imagesCollectionsUrl + '/search/findByNameContainingIgnoreCaseAndNumberOfImages', httpOptions).pipe(
       map((result: any) => {
@@ -103,7 +101,6 @@ export class ImagesCollectionService {
       const httpParams = new HttpParams().set('page', page).set('size', size).set('sort', sort);
       httpOptions.params = httpParams;
     }
-    console.log(httpOptions);
     return this.http.get<any>(`${this.imagesCollectionsUrl}/${imagesCollection.id}/images`, httpOptions).pipe(
       map((result: any) => {
         console.log(result); // <--it's an object
@@ -124,7 +121,6 @@ export class ImagesCollectionService {
       const httpParams = new HttpParams().set('page', page).set('size', size).set('sort', sort);
       httpOptions.params = httpParams;
     }
-    console.log(httpOptions);
     return this.http.get<any>(`${this.imagesCollectionsUrl}/${imagesCollection.id}/metadataFiles`, httpOptions).pipe(
       map((result: any) => {
         console.log(result); // <--it's an object

--- a/src/app/stitching-vector/stitching-vector.service.ts
+++ b/src/app/stitching-vector/stitching-vector.service.ts
@@ -7,11 +7,6 @@ import {map} from 'rxjs/operators';
 import {PaginatedTimeSlices} from './timeSlice';
 import {Job} from '../job/job';
 
-const httpOptions = {
-  headers: new HttpHeaders({'Content-Type': 'application/json'}),
-  params: {}
-};
-
 @Injectable({
   providedIn: 'root'
 })
@@ -39,6 +34,10 @@ export class StitchingVectorService {
   }
 
   getStitchingVectors(params): Observable<PaginatedStitchingVector> {
+    const httpOptions = {
+      headers: new HttpHeaders({'Content-Type': 'application/json'}),
+      params: {}
+    };
     if (params) {
       const page = params.pageIndex ? params.pageIndex : null;
       const size = params.size ? params.size : null;
@@ -49,7 +48,6 @@ export class StitchingVectorService {
     return this.http.get<any>(this.stitchingVectorsUrl, httpOptions).pipe(
       map((result: any) => {
         result.stitchingVectors = result._embedded.stitchingVectors;
-        result.job = result._embedded.job;
         return result;
       }));
   }
@@ -59,10 +57,13 @@ export class StitchingVectorService {
       headers: new HttpHeaders({ 'Content-Type': 'application/json' }),
       params: {}
     };
-    const page = params.pageIndex ? params.pageIndex : null;
-    const size = params.size ? params.size : null;
-    const sort = params.sort ? params.sort : null;
-    const httpParams = new HttpParams().set('name', name).set('page', page).set('size', size).set('sort', sort);
+    const httpParams = new HttpParams().set('name', name);
+    if (params) {
+      const page = params.pageIndex ? params.pageIndex : null;
+      const size = params.size ? params.size : null;
+      const sort = params.sort ? params.sort : null;
+      httpParams.set('page', page).set('size', size).set('sort', sort);
+    }
     httpOptions.params = httpParams;
     return this.http.get<any>(this.stitchingVectorsUrl + '/search/findByNameContainingIgnoreCase', httpOptions).pipe(
       map((result: any) => {
@@ -72,6 +73,10 @@ export class StitchingVectorService {
   }
 
   getTimeSlices(id: string, params): Observable<PaginatedTimeSlices> {
+    const httpOptions = {
+      headers: new HttpHeaders({'Content-Type': 'application/json'}),
+      params: {}
+    };
     if (params) {
       const page = params.pageIndex ? params.pageIndex : null;
       const size = params.size ? params.size : null;


### PR DESCRIPTION
fix: 
- http params handling in findByName methods in image collections and stitching vectors data services
- cleanup (logs and duplicate httpOptions)

Fixes #25 (introduced by #23)