### PR TITLE
feat: integrate wdzt as directive and add to pyramid detail view

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -20,15 +20,19 @@
             "tsConfig": "src/tsconfig.app.json",
             "assets": [
               "src/favicon.ico",
-              "src/assets"
+              "src/assets",
+              { "glob": "**/*", "input": "node_modules/@wipp/wdzt/build/deps/images", "output": "./assets/wdzt/images" }
             ],
             "styles": [
               {
                 "input": "node_modules/@angular/material/prebuilt-themes/indigo-pink.css"
               },
+              "node_modules/@wipp/wdzt/build/deps/wdzt-deps.css",
               "src/styles.css"
             ],
-            "scripts": []
+            "scripts": [
+              "node_modules/@wipp/wdzt/build/deps/js/wdzt-deps.js"
+            ]
           },
           "configurations": {
             "production": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1096,6 +1096,11 @@
         "long": "^3.2.0"
       }
     },
+    "@wipp/wdzt": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@wipp/wdzt/-/wdzt-1.0.0.tgz",
+      "integrity": "sha512-Re65ZCDdjBd+O6Kriqst7CaJmRB/7YK8fZSuOu/T8J9B4FBaduhw6j/F91J6UmhFnYZClbRdv6eHtNyjpbXeaQ=="
+    },
     "JSONStream": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.5.tgz",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@ng-bootstrap/ng-bootstrap": "^3.1.0",
     "@qontu/ngx-inline-editor": "^0.2.0-alpha.12",
     "@types/flowjs": "0.0.31",
+    "@wipp/wdzt": "^1.0.0",
     "angular-pipes": "^8.0.0",
     "bootstrap": "^4.1.3",
     "core-js": "^2.5.4",

--- a/src/app/pyramid/pyramid-detail/pyramid-detail.component.html
+++ b/src/app/pyramid/pyramid-detail/pyramid-detail.component.html
@@ -23,3 +23,5 @@
     </div>
   </div>
 </div>
+<wippWdzt [manifest]="manifest"></wippWdzt>
+

--- a/src/app/pyramid/pyramid-detail/pyramid-detail.component.ts
+++ b/src/app/pyramid/pyramid-detail/pyramid-detail.component.ts
@@ -14,6 +14,7 @@ import {PyramidService} from '../pyramid.service';
 export class PyramidDetailComponent implements OnInit {
   pyramid: Pyramid = new Pyramid();
   job: Job = null;
+  manifest: any = null;
   pyramidId = this.route.snapshot.paramMap.get('id');
 
   constructor(
@@ -27,6 +28,7 @@ export class PyramidDetailComponent implements OnInit {
       .subscribe(pyramid => {
         this.pyramid = pyramid;
         this.getJob();
+        this.getManifest(pyramid);
       });
   }
 
@@ -34,6 +36,10 @@ export class PyramidDetailComponent implements OnInit {
     if (this.pyramid._links['job']) {
       this.pyramidService.getJob(this.pyramid._links['job']['href']).subscribe(job => this.job = job);
     }
+  }
+
+  getManifest(pyramid: Pyramid) {
+    this.pyramidService.getPyramidManifest(pyramid).subscribe(manifest => this.manifest = manifest);
   }
 
   displayJobModal(jobId: string) {

--- a/src/app/pyramid/pyramid.module.ts
+++ b/src/app/pyramid/pyramid.module.ts
@@ -8,6 +8,7 @@ import {InlineEditorModule} from '@qontu/ngx-inline-editor';
 import {PyramidRoutingModule} from './pyramid-routing.module';
 import {PyramidListComponent} from './pyramid-list/pyramid-list.component';
 import {PyramidDetailComponent} from './pyramid-detail/pyramid-detail.component';
+import {WdztModule} from '../wdzt/wdzt.module';
 
 @NgModule({
   imports: [
@@ -21,7 +22,8 @@ import {PyramidDetailComponent} from './pyramid-detail/pyramid-detail.component'
     MatSortModule,
     FormsModule,
     InlineEditorModule,
-    MatCheckboxModule
+    MatCheckboxModule,
+    WdztModule
   ],
   declarations: [
     PyramidDetailComponent,

--- a/src/app/pyramid/pyramid.service.ts
+++ b/src/app/pyramid/pyramid.service.ts
@@ -1,7 +1,7 @@
 import {Injectable} from '@angular/core';
 import {environment} from '../../environments/environment';
 import {HttpClient, HttpHeaders, HttpParams} from '@angular/common/http';
-import {Observable} from 'rxjs';
+import {forkJoin, Observable, throwError} from 'rxjs';
 import {map} from 'rxjs/operators';
 import {Job} from '../job/job';
 import {PaginatedPyramid, Pyramid} from './pyramid';
@@ -42,6 +42,96 @@ export class PyramidService {
 
   getJob(jobUrl: string): Observable<Job> {
     return this.http.get<Job>(jobUrl);
+  }
+
+  getPyramidManifest(pyramid: Pyramid): any {
+    const manifest = {
+      'layersGroups': [{
+        'id': pyramid.id,
+        'name': pyramid.name,
+        'layers': [{
+          'id': pyramid.id,
+          'name': pyramid.name,
+          'baseUrl': pyramid._links.baseUri.href,
+          'framesPrefix': '',
+          'framesSuffix': '.dzi',
+          'framesOffset': -1,
+          'openOnFrame': 1,
+          'numberOfFrames': 5,
+          'paddingSize': 1,
+          'fetching': {
+            'url': pyramid._links.fetching.href
+          }
+        }]
+      }]
+    };
+    const layer: any = manifest.layersGroups[0].layers[0];
+
+    return forkJoin(
+      this.getPyramidTimeSlices(pyramid, {
+        size: 1,
+        sort: 'name,asc'
+      }),
+      this.getPyramidTimeSlices(pyramid, {
+        size: 1,
+        sort: 'name,desc'
+      }))
+      .pipe(
+        map(results => {
+          layer.numberOfFrames = results[0].page.totalElements;
+          for (let i = 0; i < results.length; i++) {
+            if (results[i].pyramidTimeSlices) {
+              results[i] = results[i].pyramidTimeSlices;
+            } else {
+              throw Error('No time slice found.');
+            }
+          }
+          return results;
+        }),
+        map(timeSlicesArray => {
+          const firstTimeSlice = timeSlicesArray[0][0];
+          const firstTimeSliceNumber = Number(firstTimeSlice.name);
+          if (isNaN(firstTimeSliceNumber)) {
+            layer.baseUrl = firstTimeSlice._links.dzi.href;
+            layer.singleFrame = true;
+          }
+
+          const lastTimeSlice = timeSlicesArray[1][0];
+          const lastTimeSliceNumber = Number(lastTimeSlice.name);
+
+          layer.paddingSize = firstTimeSlice.name.length;
+          if (lastTimeSliceNumber - firstTimeSliceNumber + 1 ===
+            layer.numberOfFrames) {
+            layer.framesOffset = firstTimeSliceNumber - 1;
+          } else {
+            return this.getPyramidTimeSlices(pyramid, {
+              size: layer.numberOfFrames
+            }).pipe(
+              map(resource => resource.pyramidTimeSlices),
+              map(timeSlices => {
+                layer.numberOfFrames = lastTimeSliceNumber;
+                layer.framesList = timeSlices.map(function (timeSlice) {
+                  return Number(timeSlice.name);
+                });
+                return firstTimeSlice;
+              }));
+          }
+          return firstTimeSlice;
+        }),
+        map( data => {
+          return manifest;
+        }));
+  }
+
+  getPyramidTimeSlices(pyramid: Pyramid, params): Observable<any> {
+    if (pyramid._links['timeSlices']) {
+      return this.http.get<any>(`${this.pyramidsUrl}/${pyramid.id}/timeSlices`, params).pipe(map(
+        (result: any) => {
+          result.pyramidTimeSlices = result._embedded.pyramidTimeSlices;
+          return result;
+        }));
+    }
+    return throwError('The pyramid has no time slices.');
   }
 
 }

--- a/src/app/wdzt/wdzt.directive.spec.ts
+++ b/src/app/wdzt/wdzt.directive.spec.ts
@@ -1,0 +1,8 @@
+import { WdztDirective } from './wdzt.directive';
+
+describe('WdztDirective', () => {
+  it('should create an instance', () => {
+    const directive = new WdztDirective();
+    expect(directive).toBeTruthy();
+  });
+});

--- a/src/app/wdzt/wdzt.directive.ts
+++ b/src/app/wdzt/wdzt.directive.ts
@@ -1,0 +1,41 @@
+import {AfterContentChecked, AfterContentInit, AfterViewInit, Directive, ElementRef, Input, OnChanges, SimpleChanges} from '@angular/core';
+
+@Directive({
+  selector: 'wippWdzt'
+})
+export class WdztDirective implements AfterViewInit, OnChanges {
+
+  @Input() public manifest: any;
+  private w: any;
+
+  constructor(private elem: ElementRef) {
+  }
+
+  ngAfterViewInit() {
+    const id = this.elem.nativeElement.id = this.elem.nativeElement.id || WDZT.guid();
+    this.w = WDZT({
+      id: id,
+      imagesPrefix: 'assets/wdzt/images/',
+      OpenSeadragon: {
+        crossOriginPolicy: 'Anonymous'
+      },
+      autoAdjustHeight: true
+    });
+  }
+
+  ngOnChanges(changes: SimpleChanges) {
+    if (changes.manifest) {
+      if (!this.manifest) {
+        return;
+      }
+      try {
+        this.manifest = typeof this.manifest === 'string'
+          ? JSON.parse(this.manifest) : this.manifest;
+        this.w.open(this.manifest);
+      } catch (er) {
+        // The manifest is probably just a URL, let WDZT deal with it.
+      }
+    }
+  }
+
+}

--- a/src/app/wdzt/wdzt.module.spec.ts
+++ b/src/app/wdzt/wdzt.module.spec.ts
@@ -1,0 +1,13 @@
+import { WdztModule } from './wdzt.module';
+
+describe('WdztModule', () => {
+  let wdztModule: WdztModule;
+
+  beforeEach(() => {
+    wdztModule = new WdztModule();
+  });
+
+  it('should create an instance', () => {
+    expect(wdztModule).toBeTruthy();
+  });
+});

--- a/src/app/wdzt/wdzt.module.ts
+++ b/src/app/wdzt/wdzt.module.ts
@@ -1,0 +1,14 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { WdztDirective } from './wdzt.directive';
+
+@NgModule({
+  imports: [
+    CommonModule
+  ],
+  declarations: [WdztDirective],
+  exports: [
+    WdztDirective
+  ]
+})
+export class WdztModule { }

--- a/src/typing.d.ts
+++ b/src/typing.d.ts
@@ -1,0 +1,2 @@
+/* WDZT custom type */
+declare var WDZT: any;


### PR DESCRIPTION
Integrate WebDeepZoomToolkit (WDZT) for pyramid visualization:
- add npm package `@wipp/wdzt`, include code as script and assets/style in `angular.json`
- create type `WDZT`
- create `wippWdzt` directive (usage: `<wippWdzt [manifest]="manifest"></wippWdzt>`) and `wdzt` module
- add manifest generation from pyramid `getPyramidManifest(pyramid: Pyramid)` in `pyramid.service.ts`
- add `wippWdzt` directive and manifest handling to pyramid detail component

Related issue: #14 