### PR TITLE
fix: prod build for ngx-graph/ngx-charts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -845,44 +845,25 @@
         "semver-intersect": "^1.1.2"
       }
     },
-    "@swimlane/ngx-graph": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/@swimlane/ngx-graph/-/ngx-graph-6.0.1.tgz",
-      "integrity": "sha512-VtaYS3evyJY/dYfubbx0LbvpWW80oPZQTpKgr0q8oV7gV59wyc6xOjpBbufwTu+lAPU/+6HrlCBr24K0uL8TwA==",
+    "@swimlane/ngx-charts": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/@swimlane/ngx-charts/-/ngx-charts-10.1.0.tgz",
+      "integrity": "sha512-0nZ3ub5o/qQfFMz+av89u/VKqsqiVhPFBDDOOPq2qimP83i+pcb0i3MEao7PSxIbKAEkL/pwRcEJw4KDZ8B67w==",
       "requires": {
-        "@swimlane/ngx-charts": "^10.0.0",
-        "d3-dispatch": "^1.0.3",
-        "d3-ease": "^1.0.5",
+        "d3": "^4.10.2",
+        "d3-array": "^1.2.1",
+        "d3-brush": "^1.0.4",
+        "d3-color": "^1.0.3",
         "d3-force": "^1.1.0",
-        "d3-selection": "^1.2.0",
+        "d3-format": "^1.2.0",
+        "d3-hierarchy": "^1.1.5",
+        "d3-interpolate": "^1.1.5",
+        "d3-scale": "^1.0.6",
+        "d3-selection": "^1.1.0",
         "d3-shape": "^1.2.0",
-        "d3-timer": "^1.0.7",
-        "d3-transition": "^1.1.1",
-        "dagre": "^0.8.4",
-        "transformation-matrix": "^1.15.3",
-        "tslib": "^1.9.0",
-        "webcola": "^3.3.8"
+        "d3-time-format": "^2.1.0"
       },
       "dependencies": {
-        "@swimlane/ngx-charts": {
-          "version": "10.1.0",
-          "resolved": "https://registry.npmjs.org/@swimlane/ngx-charts/-/ngx-charts-10.1.0.tgz",
-          "integrity": "sha512-0nZ3ub5o/qQfFMz+av89u/VKqsqiVhPFBDDOOPq2qimP83i+pcb0i3MEao7PSxIbKAEkL/pwRcEJw4KDZ8B67w==",
-          "requires": {
-            "d3": "^4.10.2",
-            "d3-array": "^1.2.1",
-            "d3-brush": "^1.0.4",
-            "d3-color": "^1.0.3",
-            "d3-force": "^1.1.0",
-            "d3-format": "^1.2.0",
-            "d3-hierarchy": "^1.1.5",
-            "d3-interpolate": "^1.1.5",
-            "d3-scale": "^1.0.6",
-            "d3-selection": "^1.1.0",
-            "d3-shape": "^1.2.0",
-            "d3-time-format": "^2.1.0"
-          }
-        },
         "d3": {
           "version": "4.13.0",
           "resolved": "https://registry.npmjs.org/d3/-/d3-4.13.0.tgz",
@@ -918,15 +899,29 @@
             "d3-transition": "1.1.1",
             "d3-voronoi": "1.1.2",
             "d3-zoom": "1.7.1"
-          },
-          "dependencies": {
-            "d3-ease": {
-              "version": "1.0.3",
-              "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-1.0.3.tgz",
-              "integrity": "sha1-aL+8NJM4o4DETYrMT7wzBKotjA4="
-            }
           }
-        },
+        }
+      }
+    },
+    "@swimlane/ngx-graph": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@swimlane/ngx-graph/-/ngx-graph-6.0.1.tgz",
+      "integrity": "sha512-VtaYS3evyJY/dYfubbx0LbvpWW80oPZQTpKgr0q8oV7gV59wyc6xOjpBbufwTu+lAPU/+6HrlCBr24K0uL8TwA==",
+      "requires": {
+        "@swimlane/ngx-charts": "^10.0.0",
+        "d3-dispatch": "^1.0.3",
+        "d3-ease": "^1.0.5",
+        "d3-force": "^1.1.0",
+        "d3-selection": "^1.2.0",
+        "d3-shape": "^1.2.0",
+        "d3-timer": "^1.0.7",
+        "d3-transition": "^1.1.1",
+        "dagre": "^0.8.4",
+        "transformation-matrix": "^1.15.3",
+        "tslib": "^1.9.0",
+        "webcola": "^3.3.8"
+      },
+      "dependencies": {
         "d3-ease": {
           "version": "1.0.5",
           "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-1.0.5.tgz",
@@ -1281,7 +1276,6 @@
       "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
       "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
       "dev": true,
-      "optional": true,
       "requires": {
         "kind-of": "^3.0.2",
         "longest": "^1.0.1",
@@ -1293,7 +1287,6 @@
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
-          "optional": true,
           "requires": {
             "is-buffer": "^1.1.5"
           }
@@ -1377,7 +1370,6 @@
       "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
       "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
       "dev": true,
-      "optional": true,
       "requires": {
         "delegates": "^1.0.0",
         "readable-stream": "^2.0.6"
@@ -2687,8 +2679,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
       "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "constants-browserify": {
       "version": "1.0.0",
@@ -3571,8 +3562,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
       "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "depd": {
       "version": "1.1.2",
@@ -4747,8 +4737,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -4769,14 +4758,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -4791,20 +4778,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -4921,8 +4905,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -4934,7 +4917,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -4949,7 +4931,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -4957,14 +4938,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -4983,7 +4962,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -5064,8 +5042,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -5077,7 +5054,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -5163,8 +5139,7 @@
         "safe-buffer": {
           "version": "5.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -5200,7 +5175,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -5220,7 +5194,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -5264,14 +5237,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },
@@ -5280,7 +5251,6 @@
       "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
       "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
       "dev": true,
-      "optional": true,
       "requires": {
         "graceful-fs": "^4.1.2",
         "inherits": "~2.0.0",
@@ -5299,7 +5269,6 @@
       "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
       "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
       "dev": true,
-      "optional": true,
       "requires": {
         "aproba": "^1.0.3",
         "console-control-strings": "^1.0.0",
@@ -5755,8 +5724,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
       "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "has-value": {
       "version": "1.0.0",
@@ -7642,8 +7610,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
       "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "loose-envify": {
       "version": "1.4.0",
@@ -8374,7 +8341,6 @@
       "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
       "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
       "dev": true,
-      "optional": true,
       "requires": {
         "are-we-there-yet": "~1.1.2",
         "console-control-strings": "~1.1.0",
@@ -12104,7 +12070,6 @@
       "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
       "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
       "dev": true,
-      "optional": true,
       "requires": {
         "string-width": "^1.0.2 || 2"
       }


### PR DESCRIPTION
Fix for WIPP-frontend not building in prod mode with `npm ci` because of missing `ngx-charts` dependency in package-lock.json