### PR TITLE
fix: fixed numbering in image collection detail view

### DIFF
--- a/src/app/images-collection/images-collection-detail/images-collection-detail.component.html
+++ b/src/app/images-collection/images-collection-detail/images-collection-detail.component.html
@@ -203,7 +203,7 @@
     <ng-container matColumnDef="index">
       <th mat-header-cell *matHeaderCellDef>#</th>
       <td mat-cell *matCellDef="let id=index">
-        {{ (pageSize * imagesPaginator.pageIndex) + id + 1 }}
+        {{ (pageSizeImages * imagesPaginator.pageIndex) + id + 1 }}
       </td>
     </ng-container>
 
@@ -256,8 +256,7 @@
     <tr mat-row *matRowDef="let row; columns: displayedColumnsImages;"></tr>
   </table>
 
-
-  <mat-paginator (page)="imagesPageChanged($event)" [length]="resultsLengthImages" [pageSize]="pageSize" #imagesPaginator [pageSizeOptions]="pageSizeOptions"></mat-paginator>
+  <mat-paginator (page)="imagesPageChanged($event)" [length]="resultsLengthImages" [pageSize]="pageSizeImages" #imagesPaginator [pageSizeOptions]="pageSizeOptions"></mat-paginator>
 
   <h4>Metadata files</h4>
   <div class='row'>
@@ -288,7 +287,7 @@
     <ng-container matColumnDef="index">
       <th mat-header-cell *matHeaderCellDef>#</th>
       <td mat-cell *matCellDef="let id=index">
-        {{ (pageSize * metadataFilesPaginator.pageIndex) + id + 1 }}
+        {{ (pageSizeMetadataFiles * metadataFilesPaginator.pageIndex) + id + 1 }}
       </td>
     </ng-container>
 
@@ -333,5 +332,6 @@
   </table>
 
 
-  <mat-paginator (page)="metadataPageChanged($event)" [length]="resultsLengthMetadataFiles" [pageSize]="pageSize" [pageSizeOptions]="pageSizeOptions" #metadataFilesPaginator></mat-paginator>
+  <mat-paginator (page)="metadataPageChanged($event)" [length]="resultsLengthMetadataFiles" [pageSize]="pageSizeMetadataFiles" [pageSizeOptions]="pageSizeOptions" #metadataFilesPaginator></mat-paginator>
+
 </div>

--- a/src/app/images-collection/images-collection-detail/images-collection-detail.component.ts
+++ b/src/app/images-collection/images-collection-detail/images-collection-detail.component.ts
@@ -38,7 +38,8 @@ export class ImagesCollectionDetailComponent implements OnInit, AfterViewInit {
   uploadOption = 'regular';
   resultsLengthImages = 0;
   resultsLengthMetadataFiles = 0;
-  pageSize = 10;
+  pageSizeImages = 10;
+  pageSizeMetadataFiles = 10;
   imageCollectionId = this.route.snapshot.paramMap.get('id');
 
   @ViewChild('browseBtn') browseBtn: ElementRef;
@@ -58,12 +59,12 @@ export class ImagesCollectionDetailComponent implements OnInit, AfterViewInit {
     private imagesCollectionService: ImagesCollectionService) {
     this.imagesParamsChange = new BehaviorSubject({
       index: 0,
-      size: this.pageSize,
+      size: this.pageSizeImages,
       sort: ''
     });
     this.metadataParamsChange = new BehaviorSubject({
       index: 0,
-      size: this.pageSize,
+      size: this.pageSizeMetadataFiles,
       sort: ''
     });
   }
@@ -75,6 +76,7 @@ export class ImagesCollectionDetailComponent implements OnInit, AfterViewInit {
 
   imagesPageChanged(page) {
     this.imagesParamsChange.next({index: page.pageIndex, size: page.pageSize, sort: this.imagesParamsChange.value.sort});
+    this.pageSizeImages = page.pageSize;
   }
 
   metadataSortChanged(sort) {
@@ -84,6 +86,7 @@ export class ImagesCollectionDetailComponent implements OnInit, AfterViewInit {
 
   metadataPageChanged(page) {
     this.metadataParamsChange.next({index: page.pageIndex, size: page.pageSize, sort: this.metadataParamsChange.value.sort});
+    this.pageSizeMetadataFiles = page.pageSize;
   }
 
   ngOnInit() {


### PR DESCRIPTION
issue #49 
separated page size of images from page size of metadata files
updated the index when modifying the number of items per page

@MyleneSimon 