### PR TITLE
fix: pyramids location in nginx conf

### DIFF
--- a/deploy/docker/default.conf
+++ b/deploy/docker/default.conf
@@ -14,12 +14,12 @@ server {
   }
   
   # Pyramid tiles fetching 
-  location ^~ /pyramids/ {
+  location ^~ /pyramid-files/ {
     proxy_set_header X-Real-IP $remote_addr;
     proxy_set_header Host $http_host;
     proxy_http_version 1.1;
 
-    proxy_pass http://@backend_host@:@backend_port@/pyramids/;
+    proxy_pass http://@backend_host@:@backend_port@/pyramid-files/;
   }
 
   # Frontend JS application


### PR DESCRIPTION
Updated nginx conf to match new pyramid resource path
Related issue: #46 
Related PR in backend: https://github.com/usnistgov/WIPP-backend/pull/78