### PR TITLE
Always pull a new image

### DIFF
--- a/deploy/kubernetes/frontend-deployment.yaml
+++ b/deploy/kubernetes/frontend-deployment.yaml
@@ -15,6 +15,7 @@ spec:
       containers:
       - image: labshare/wipp-frontend:FRONTEND_VERSION_VALUE
         name: wipp-frontend
+        imagePullPolicy: Always
         args: ["wipp-backend", "8080"]
         ports:
         - containerPort: 80


### PR DESCRIPTION
We need to pull a new image every time update is pushed since we are developing against the same version of wipp-frontend:3.0.0.