### PR TITLE
fix: get all plugins sorted by names when creating a job

### DIFF
--- a/src/app/workflow/workflow-detail/workflow-detail.component.ts
+++ b/src/app/workflow/workflow-detail/workflow-detail.component.ts
@@ -48,7 +48,7 @@ export class WorkflowDetailComponent implements OnInit {
   ngOnInit() {
     this.workflowService.getWorkflow(this.workflowId).subscribe(workflow =>
       this.workflow = workflow);
-    this.pluginService.getPlugins(null)
+    this.pluginService.getPlugins({ size: Number.MAX_SAFE_INTEGER, sort: 'name' })
       .subscribe(plugins => {
         this.pluginList = plugins.plugins;
         this.generateSchema(this.pluginList);


### PR DESCRIPTION
Set search params to `{size:Number.MAX_SAFE_INTEGER, sort: 'name'}` to avoid only getting the 10 first plugins (default page size) and sort by name.
Fixes #93 