### PR TITLE
fix: add missing style for wdzt

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -20,3 +20,7 @@ table {
   margin-top: -15px;
 }
 
+wippwdzt {
+  display: block;
+  width: 100%;
+}


### PR DESCRIPTION
Style for `wippWdzt` directive was missing, causing deep zoom view to not be displayed other than in Chrome.
Fixes issue #41 