### PR TITLE
feat: add catalog url management for deployment

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -42,6 +42,7 @@ pipeline {
                         env.JUPYTERHUB_URL = urls.JUPYTERHUB_URL
                         env.VISIONUI_URL = urls.VISIONUI_URL
                         env.ARGOUIBASE_URL = urls.ARGOUIBASE_URL
+                        env.CATALOGUI_URL = urls.CATALOGUI_URL
                         env.FRONTEND_HOST_NAME = urls.FRONTEND_HOST_NAME
                     }
                 }
@@ -98,6 +99,7 @@ pipeline {
                         sh "sed -i 's|JUPYTERHUB_URL_VALUE|${JUPYTERHUB_URL}|g' frontend-deployment.yaml"
                         sh "sed -i 's|VISIONUI_URL_VALUE|${VISIONUI_URL}|g' frontend-deployment.yaml"
                         sh "sed -i 's|ARGOUIBASE_URL_VALUE|${ARGOUIBASE_URL}|g' frontend-deployment.yaml"
+                        sh "sed -i 's|CATALOGUI_URL_VALUE|${CATALOGUI_URL}|g' frontend-deployment.yaml"
                         sh "sed -i 's/FRONTEND_HOST_NAME_VALUE/${FRONTEND_HOST_NAME}/g' services.yaml"
                     }
                     withAWS(credentials:'aws-jenkins-eks') {

--- a/deploy/docker/config.json
+++ b/deploy/docker/config.json
@@ -2,5 +2,6 @@
   "tensorboardUrl": "TENSORBOARD_URL",
   "jupyterNotebooksUrl": "JUPYTERHUB_URL",
   "plotsUiUrl": "VISIONUI_URL",
-  "argoUiBaseUrl": "ARGOUIBASE_URL"
+  "argoUiBaseUrl": "ARGOUIBASE_URL",
+  "catalogUiUrl": "CATALOGUI_URL"
 }

--- a/deploy/docker/entrypoint.sh
+++ b/deploy/docker/entrypoint.sh
@@ -20,6 +20,7 @@ sed -i \
   -e 's|TENSORBOARD_URL|'"${TENSORBOARD_URL}"'|' \
   -e 's|JUPYTERHUB_URL|'"${JUPYTERHUB_URL}"'|' \
   -e 's|VISIONUI_URL|'"${VISIONUI_URL}"'|' \
+  -e 's|CATALOGUI_URL|'"${CATALOGUI_URL}"'|' \
   -e 's|ARGOUIBASE_URL|'"${ARGOUIBASE_URL}"'|' \
   /var/www/frontend/assets/config/config.json
 

--- a/deploy/kubernetes/frontend-deployment.yaml
+++ b/deploy/kubernetes/frontend-deployment.yaml
@@ -24,6 +24,8 @@ spec:
           value: JUPYTERHUB_URL_VALUE
         - name: VISIONUI_URL
           value: VISIONUI_URL_VALUE
+        - name: CATALOGUI_URL
+            value: CATALOGUI_URL_VALUE
         ports:
         - containerPort: 80
       restartPolicy: Always


### PR DESCRIPTION
<!--
Please fill in the following template, and make sure your are following the contributing guidelines before submitting this PR
-->

## What does this PR do?

Add management of CatalogUI URL for deployment:
- update frontend `config.json` for Docker image,
- add sed of `CATALOGUI_URL` from env variable in Docker image's entrypoint,
- add `CATALOGUI_URL` env variable to front deployment yaml,
- add `CATALOGUI_URL_VALUE` sed in Jenkinsfile

Note: `env-ci.json` will have to be updated to add the `CATALOGUI_URL` value @sunnielyu

## Related issues

#141 