### PR TITLE
fix: avoid duplicated job dependencies during job creation

### DIFF
--- a/src/app/workflow/workflow-detail/workflow-detail.component.ts
+++ b/src/app/workflow/workflow-detail/workflow-detail.component.ts
@@ -123,7 +123,9 @@ export class WorkflowDetailComponent implements OnInit, OnDestroy {
             type === 'csvCollection' ||
             type === 'notebook') {
             if (value.hasOwnProperty('virtual') && value.virtual === true && value.hasOwnProperty('sourceJob')) {
-              task['dependencies'].push(value.sourceJob);
+              if (task['dependencies'].indexOf(value.sourceJob) === -1) {
+                task['dependencies'].push(value.sourceJob);
+              }
             }
             value = value.hasOwnProperty('id') ? value.id : null;
           }


### PR DESCRIPTION
<!--
Please fill in the following template, and make sure your are following the contributing guidelines before submitting this PR
-->

## What does this PR do?

Fixes duplicated dependencies when created a job that takes multiple inputs that are outputs of the same job (checks if job dependency, ie input's source job id, is already present before adding it to the list).
