### PR TITLE
fix: default values from manifest for non-enum types in job form

### DIFF
--- a/src/app/workflow/workflow-detail/workflow-detail.component.ts
+++ b/src/app/workflow/workflow-detail/workflow-detail.component.ts
@@ -343,7 +343,7 @@ export class WorkflowDetailComponent implements OnInit, OnDestroy {
             ];
           }
           if (ui.hasOwnProperty('default')) {
-            inputSchema['default'] = input.default;
+            inputSchema['default'] = ui.default;
           }
           plugin.properties.inputs.properties[input.name] = inputSchema;
         });


### PR DESCRIPTION
<!--
Please fill in the following template, and make sure your are following the contributing guidelines before submitting this PR
-->

## What does this PR do?

Fix handling of default values present in plugin manifest for non-enum input types in job form.

