### PR TITLE
fix: sort by size in imagesCollection details page

### DIFF
--- a/src/app/images-collection/images-collection-detail/images-collection-detail.component.html
+++ b/src/app/images-collection/images-collection-detail/images-collection-detail.component.html
@@ -277,7 +277,7 @@
     </ng-container>
 
     <!-- FileSize Column -->
-    <ng-container matColumnDef="size">
+    <ng-container matColumnDef="fileSize">
       <th mat-header-cell *matHeaderCellDef mat-sort-header>Size</th>
       <td mat-cell *matCellDef="let row">{{ row.fileSize | bytes }}</td>
     </ng-container>
@@ -386,7 +386,7 @@
     </ng-container>
 
     <!-- FileSize Column -->
-    <ng-container matColumnDef="size">
+    <ng-container matColumnDef="fileSize">
       <th mat-header-cell *matHeaderCellDef mat-sort-header>Size</th>
       <td mat-cell *matCellDef="let row">{{ row.fileSize | bytes }}</td>
     </ng-container>

--- a/src/app/images-collection/images-collection-detail/images-collection-detail.component.ts
+++ b/src/app/images-collection/images-collection-detail/images-collection-detail.component.ts
@@ -36,8 +36,8 @@ export class ImagesCollectionDetailComponent implements OnInit, AfterViewInit {
   editNotes = false;
   imageCollectionNotes;
 
-  displayedColumnsImages: string[] = ['index', 'fileName', 'size', 'actions'];
-  displayedColumnsMetadata: string[] = ['index', 'fileName', 'size', 'actions'];
+  displayedColumnsImages: string[] = ['index', 'fileName', 'fileSize', 'actions'];
+  displayedColumnsMetadata: string[] = ['index', 'fileName', 'fileSize', 'actions'];
 
   pageSizeOptions: number[] = [10, 25, 50, 100];
   imagesParamsChange: BehaviorSubject<{ index: number, size: number, sort: string }>;


### PR DESCRIPTION
<!--
Please fill in the following template, and make sure your are following the contributing guidelines before submitting this PR
-->

## What does this PR do?

changed "size" to "fileSize" to fix sort issue in imagesCollection details page 

## Related issues

#152 