### PR TITLE
feat: add help links to menu bar

### DIFF
--- a/src/app/app.component.css
+++ b/src/app/app.component.css
@@ -41,6 +41,11 @@ a:not([href]).dropdown-toggle:hover {
   font-weight: normal
 }
 
+.dropdown-menu-right {
+  right: 0;
+  left: auto;
+}
+
 .main-container {
   width: 98%;
   min-height: 100vh;

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -61,6 +61,19 @@
           </a>
         </li>
       </ul>
+      <ul class="navbar-nav ml-auto">
+        <li class="nav-item dropdown" routerLinkActive="active" ngbDropdown>
+          <a class="nav-link dropdown-toggle" id="helpDropdown" routerLinkActive="active" ngbDropdownToggle>
+            <i class="fas fa-question-circle">
+              <p>Help</p>
+            </i>
+          </a>
+          <div class="dropdown-menu dropdown-menu-right" aria-labelledby="helpDropdown" ngbDropdownMenu>
+            <a class="dropdown-item" href={{onlineHelpLink}} ngbDropdownItem>User guide</a>
+            <a class="dropdown-item" href={{apiDocsLink}} ngbDropdownItem>API docs</a>
+          </div>
+        </li>
+      </ul>
     </div>
   </nav>
 </header>

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -13,6 +13,8 @@ export class AppComponent {
   isNavbarCollapsed = true;
   jupyterNotebooksLink = '';
   plotsUiLink = '';
+  onlineHelpLink = 'https://github.com/usnistgov/WIPP/tree/master/user-guide';
+  apiDocsLink = environment.apiRootUrl + '/swagger-ui.html';
 
   constructor(private appConfigService: AppConfigService) {
     this.jupyterNotebooksLink = this.appConfigService.getConfig().jupyterNotebooksUrl;


### PR DESCRIPTION
<!--
Please fill in the following template, and make sure your are following the contributing guidelines before submitting this PR
-->

## What does this PR do?

Add new "Help" item to nav bar (right placement), with dropdowns for "User guide" (WIPP repo) and "API docs" (Swagger UI).
