### PR TITLE
fix: add brackets to name of previous inputs when copy/edit a task

### DIFF
--- a/src/app/workflow/workflow-detail/workflow-detail.component.ts
+++ b/src/app/workflow/workflow-detail/workflow-detail.component.ts
@@ -408,7 +408,7 @@ export class WorkflowDetailComponent implements OnInit, OnDestroy {
                   jobToCopy.parameters[input].length - 3
                 );
                 const prevJob = this.jobs.find(x => x.id === prevId);
-                this.jobModel['inputs'][input]['name'] = prevJob.name + prevOutputName;
+                this.jobModel['inputs'][input]['name'] = '{{ ' + prevJob.name + prevOutputName + ' }}';
                 this.jobModel['inputs'][input]['virtual'] = true;
                 this.jobModel['inputs'][input]['sourceJob'] = prevId;
               }


### PR DESCRIPTION
<!--
Please fill in the following template, and make sure your are following the contributing guidelines before submitting this PR
-->

## What does this PR do?

Add brackets to  the name of chained inputs when copying / editing a task in a workflow

## Related issues

#150 
