### PR TITLE
feat: link to Swagger Ui disabled in production

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -70,7 +70,7 @@
           </a>
           <div class="dropdown-menu dropdown-menu-right" aria-labelledby="helpDropdown" ngbDropdownMenu>
             <a class="dropdown-item" href={{onlineHelpLink}} ngbDropdownItem>User guide</a>
-            <a class="dropdown-item" href={{apiDocsLink}} ngbDropdownItem>API docs</a>
+            <a class="dropdown-item" href={{apiDocsLink}} ngbDropdownItem *ngIf="displayApiDocsLink">API docs</a>
           </div>
         </li>
       </ul>

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -15,6 +15,7 @@ export class AppComponent {
   plotsUiLink = '';
   onlineHelpLink = 'https://github.com/usnistgov/WIPP/tree/master/user-guide';
   apiDocsLink = environment.apiRootUrl + '/swagger-ui.html';
+  displayApiDocsLink = !environment.production;
 
   constructor(private appConfigService: AppConfigService) {
     this.jupyterNotebooksLink = this.appConfigService.getConfig().jupyterNotebooksUrl;


### PR DESCRIPTION
<!--
Please fill in the following template, and make sure your are following the contributing guidelines before submitting this PR
-->

## What does this PR do?

Link from frontend to Swagger UI is only displayed in dev mode.

