### PR TITLE
fix: fixed pyramid annotations url

### DIFF
--- a/src/app/pyramid/pyramid.service.ts
+++ b/src/app/pyramid/pyramid.service.ts
@@ -83,11 +83,11 @@ export class PyramidService implements DataService<Pyramid, PaginatedPyramid> {
           'paddingSize': 1,
           'fetching': {
             'url': pyramid._links.fetching.href
+          },
+          'pyramidAnnotations': {
+            'serviceUrl': this.pyramidAnnotationsUrl
           }
-        }],
-        'pyramidAnnotations': {
-          'serviceUrl': this.pyramidAnnotationsUrl
-        }
+        }]
       }]
     };
     const layer: any = manifest.layersGroups[0].layers[0];


### PR DESCRIPTION
## What does this PR do?

fixes pyramid annotations url so it can be used by wdzt. 


