### PR TITLE
fix: floating numbers in job form

### DIFF
--- a/src/app/workflow/workflow-detail/workflow-detail.component.ts
+++ b/src/app/workflow/workflow-detail/workflow-detail.component.ts
@@ -271,6 +271,12 @@ export class WorkflowDetailComponent implements OnInit, OnDestroy {
               inputSchema['format'] = 'array';
               inputSchema['items'] = input.options.items;
               break;
+            // Workaround for https://github.com/guillotinaweb/ngx-schema-form/issues/332
+            case 'number':
+            case 'float':
+              inputSchema['type'] = 'string';
+              inputSchema['widget'] = 'integer';
+              break;
             default:
               inputSchema['type'] = input.type;
           }


### PR DESCRIPTION
<!--
Please fill in the following template, and make sure your are following the contributing guidelines before submitting this PR
-->

## What does this PR do?

Fix for #143 (user unable to enter floating numbers with 0 after decimal point in new task form).
Workaround is to handle number as string while still using number widget as recommended by `ngx-schema-form` team.

## Related issues

#143 