### PR TITLE
feat: delete locked collections

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -29,6 +29,8 @@ import {PyramidVisualizationModule} from './pyramid-visualization/pyramid-visual
 import { ForbiddenAccessComponent } from './forbidden-access/forbidden-access.component';
 import {PyramidAnnotationModule} from './pyramid-annotation/pyramid-annotation.module';
 import { GenericDataModule } from './generic-data/generic-data.module';
+import {ConfirmDialogService} from './confirm-dialog/confirm-dialog.service';
+import {ConfirmDialogModule} from './confirm-dialog/confirm-dialog.module';
 
 @NgModule({
   declarations: [
@@ -51,6 +53,7 @@ import { GenericDataModule } from './generic-data/generic-data.module';
     GenericDataModule,
     PluginModule,
     WorkflowModule,
+    ConfirmDialogModule,
     AppRoutingModule,
     BrowserAnimationsModule,
     MatInputModule,
@@ -75,7 +78,8 @@ import { GenericDataModule } from './generic-data/generic-data.module';
       useClass: KeycloakInterceptorService,
       multi: true
     },
-    KeycloakService
+    KeycloakService,
+    ConfirmDialogService
   ],
   bootstrap: [AppComponent]
 })

--- a/src/app/confirm-dialog/confirm-dialog.component.css
+++ b/src/app/confirm-dialog/confirm-dialog.component.css
@@ -1,0 +1,3 @@
+.modal-body p {
+  word-wrap: break-word;
+}

--- a/src/app/confirm-dialog/confirm-dialog.component.html
+++ b/src/app/confirm-dialog/confirm-dialog.component.html
@@ -1,0 +1,16 @@
+<div class="modal-header bg-light">
+  <h4 class="modal-title">{{title}}</h4>
+  <button type="button" class="close" aria-label="Close" (click)="onDismiss()">
+    <span aria-hidden="true">&times;</span>
+  </button>
+</div>
+<div class="modal-body">
+  <div class="alert alert-warning" *ngFor="let warning of warnings" role="alert">
+    Warning: {{warning}}
+  </div>
+  <div>{{message}}</div>
+</div>
+<div class="modal-footer">
+  <button type="button" class="btn btn-outline-dark" (click)="onDismiss()">Cancel</button>
+  <button type="button" class="btn btn-danger" ngbAutofocus (click)="onConfirm()">Confirm</button>
+</div>

--- a/src/app/confirm-dialog/confirm-dialog.component.spec.ts
+++ b/src/app/confirm-dialog/confirm-dialog.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ConfirmDialogComponent } from './confirm-dialog.component';
+
+describe('ConfirmDialogComponent', () => {
+  let component: ConfirmDialogComponent;
+  let fixture: ComponentFixture<ConfirmDialogComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ ConfirmDialogComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(ConfirmDialogComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/confirm-dialog/confirm-dialog.component.ts
+++ b/src/app/confirm-dialog/confirm-dialog.component.ts
@@ -1,0 +1,30 @@
+import {Component, Input, OnInit} from '@angular/core';
+import {NgbActiveModal} from '@ng-bootstrap/ng-bootstrap';
+
+@Component({
+  selector: 'app-confirm-dialog',
+  templateUrl: './confirm-dialog.component.html',
+  styleUrls: ['./confirm-dialog.component.css']
+})
+export class ConfirmDialogComponent implements OnInit {
+
+  @Input() title: string;
+  @Input() message: string;
+  @Input() warnings: string[]
+
+  constructor(
+    public activeModal: NgbActiveModal
+  ) { }
+
+  ngOnInit() {
+  }
+
+  onConfirm(): void {
+    this.activeModal.close(true);
+  }
+
+  onDismiss(): void {
+    this.activeModal.close(false);
+  }
+
+}

--- a/src/app/confirm-dialog/confirm-dialog.module.ts
+++ b/src/app/confirm-dialog/confirm-dialog.module.ts
@@ -1,0 +1,18 @@
+import {NgModule} from '@angular/core';
+import {CommonModule} from '@angular/common';
+import {ConfirmDialogComponent} from './confirm-dialog.component';
+
+@NgModule({
+  imports: [
+    CommonModule,
+  ],
+  declarations: [
+    ConfirmDialogComponent],
+  entryComponents: [
+    ConfirmDialogComponent
+  ],
+  exports: [
+    ConfirmDialogComponent
+  ]
+})
+export class ConfirmDialogModule { }

--- a/src/app/confirm-dialog/confirm-dialog.service.spec.ts
+++ b/src/app/confirm-dialog/confirm-dialog.service.spec.ts
@@ -1,0 +1,12 @@
+import { TestBed } from '@angular/core/testing';
+
+import { ConfirmDialogService } from './confirm-dialog.service';
+
+describe('ConfirmDialogService', () => {
+  beforeEach(() => TestBed.configureTestingModule({}));
+
+  it('should be created', () => {
+    const service: ConfirmDialogService = TestBed.get(ConfirmDialogService);
+    expect(service).toBeTruthy();
+  });
+});

--- a/src/app/confirm-dialog/confirm-dialog.service.ts
+++ b/src/app/confirm-dialog/confirm-dialog.service.ts
@@ -1,0 +1,21 @@
+import { Injectable } from '@angular/core';
+import {NgbModal, NgbModalRef} from '@ng-bootstrap/ng-bootstrap';
+import {ConfirmDialogComponent} from './confirm-dialog.component';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class ConfirmDialogService {
+
+  constructor(
+    private modalService: NgbModal,
+  ) { }
+
+  createConfirmModal(title: string, message: string, warnings: string[]): NgbModalRef {
+    const modalRefConfirm = this.modalService.open(ConfirmDialogComponent);
+    modalRefConfirm.componentInstance.title = title;
+    modalRefConfirm.componentInstance.message = message;
+    modalRefConfirm.componentInstance.warnings = warnings;
+    return modalRefConfirm;
+  }
+}

--- a/src/app/images-collection/images-collection-detail/images-collection-detail.component.html
+++ b/src/app/images-collection/images-collection-detail/images-collection-detail.component.html
@@ -126,8 +126,9 @@
       <!--data-tooltip-placement="left">-->
       <!--<span class="glyphicon glyphicon-copy"></span>-->
       <!--</button>-->
-      <button *ngIf="!imagesCollection.locked && canEdit()" type="button"
+      <button *ngIf="canEdit()" type="button"
               ngbTooltip="Delete collection"
+              [disabled]="imagesCollection.publiclyShared && !canDeletePublicData()"
               placement="left"
               class="btn btn-light" (click)="deleteCollection();">
                   <span class="fa fa-times"

--- a/src/app/images-collection/images-collection-detail/images-collection-detail.component.ts
+++ b/src/app/images-collection/images-collection-detail/images-collection-detail.component.ts
@@ -17,6 +17,7 @@ import urljoin from 'url-join';
 import {AppConfigService} from '../../app-config.service';
 import {KeycloakService} from '../../services/keycloak/keycloak.service';
 import {ModalErrorComponent} from '../../modal-error/modal-error.component';
+import {ConfirmDialogService} from '../../confirm-dialog/confirm-dialog.service';
 
 @Component({
   selector: 'app-images-collection-detail',
@@ -72,7 +73,8 @@ export class ImagesCollectionDetailComponent implements OnInit, AfterViewInit {
     private modalService: NgbModal,
     private imagesCollectionService: ImagesCollectionService,
     private appConfigService: AppConfigService,
-    private keycloakService: KeycloakService
+    private keycloakService: KeycloakService,
+    private confirmDialogService: ConfirmDialogService
     ) {
     this.imagesParamsChange = new BehaviorSubject({
       index: 0,
@@ -89,6 +91,11 @@ export class ImagesCollectionDetailComponent implements OnInit, AfterViewInit {
   canEdit(): boolean {
     return this.keycloakService.canEdit(this.imagesCollection);
   }
+
+  canDeletePublicData(): boolean {
+    return this.keycloakService.canDeletePublicData();
+  }
+
   imagesSortChanged(sort) {
     // If the user changes the sort order, reset back to the first page.
     this.imagesParamsChange.next({index: 0, size: this.imagesParamsChange.value.size, sort: sort.active + ',' + sort.direction});
@@ -249,13 +256,26 @@ export class ImagesCollectionDetailComponent implements OnInit, AfterViewInit {
   }
 
   makePublicCollection(): void {
-    this.imagesCollectionService.makePublicImagesCollection(
-      this.imagesCollection).subscribe(imagesCollection => {
-      this.imagesCollection = imagesCollection;
-    }, error => {
-      const modalRefErr = this.modalService.open(ModalErrorComponent);
-      modalRefErr.componentInstance.title = 'Error while changing Images Collection visibility to public';
-      modalRefErr.componentInstance.message = error.error;
+    const title = 'Make public';
+    const message = 'Are you sure you want to make this collection public? ' +
+      'This action cannot be undone.';
+    const warnings: string[] = [];
+    warnings.push('Once public, all users will be able to see and use the collection.');
+    warnings.push('Once public, the collection cannot be deleted except by an admin user.');
+    const modalRefConfirm = this.confirmDialogService.createConfirmModal(
+      title, message, warnings
+    );
+    modalRefConfirm.result.then((confirm) => {
+      if (confirm) {
+        this.imagesCollectionService.makePublicImagesCollection(
+          this.imagesCollection).subscribe(imagesCollection => {
+          this.imagesCollection = imagesCollection;
+        }, error => {
+          const modalRefErr = this.modalService.open(ModalErrorComponent);
+          modalRefErr.componentInstance.title = 'Unable to make public';
+          modalRefErr.componentInstance.message = error.error;
+        });
+      }
     });
   }
 
@@ -267,11 +287,27 @@ export class ImagesCollectionDetailComponent implements OnInit, AfterViewInit {
   }
 
   deleteCollection(): void {
-    if (confirm('Are you sure you want to delete the collection ' + this.imagesCollection.name + '?')) {
-      this.imagesCollectionService.deleteImagesCollection(this.imagesCollection).subscribe(collection => {
-        this.router.navigate(['images-collections']);
-      });
+    const title = 'Delete collection';
+    const message = 'Are you sure you want to delete the collection ' +
+      this.imagesCollection.name + '? ' +
+      'This action cannot be undone.';
+    const warnings: string[] = [];
+    if (this.imagesCollection.locked) {
+      warnings.push('This collection is locked.');
     }
+    if (this.imagesCollection.publiclyShared) {
+      warnings.push('This collection is public, multiple users may be impacted.');
+    }
+    const modalRefConfirm = this.confirmDialogService.createConfirmModal(
+      title, message, warnings
+    );
+    modalRefConfirm.result.then((confirm) => {
+      if (confirm) {
+        this.imagesCollectionService.deleteImagesCollection(this.imagesCollection).subscribe(collection => {
+          this.router.navigate(['images-collections']);
+        });
+      }
+    });
   }
 
   deleteImage(image: Image): void {

--- a/src/app/images-collection/images-collection-template/images-collection-template.component.ts
+++ b/src/app/images-collection/images-collection-template/images-collection-template.component.ts
@@ -20,6 +20,9 @@ export class ImagesCollectionTemplateComponent extends DynamicComponent implemen
   ngOnInit() {
       this.imagesCollectionService.getById(this.idData).subscribe(result => {
         this.text = result.name;
+      },
+      error => {
+        this.text = 'N/A';
       });
   }
 }

--- a/src/app/services/keycloak/keycloak.service.ts
+++ b/src/app/services/keycloak/keycloak.service.ts
@@ -105,4 +105,13 @@ export class KeycloakService {
       }
       return false;
     }
+
+    canDeletePublicData(): boolean {
+      if (this.isLoggedIn()) {
+        if (this.hasRole('admin')) {
+          return true;
+        }
+      }
+      return false;
+    }
 }


### PR DESCRIPTION
<!--
Please fill in the following template, and make sure your are following the contributing guidelines before submitting this PR
-->

## What does this PR do?

Changes:
- allow users to delete locked collections
  - users can delete their own private collections, locked or not (confirmation asked)
  - admins can delete any collections, regardless of lock or visibility status (confirmation asked)
- add confirm dialog component and service 
- add confirmation dialogs for making collections public and deleting collections, with custom warnings

Screenshots:

User deletes private unlocked collection:
<img width="1258" alt="Screen Shot 2021-04-22 at 11 13 42 AM" src="https://user-images.githubusercontent.com/3227182/115740853-3ae05b00-a35d-11eb-8b1f-e022ba5adace.png">

User deletes private locked collection:
<img width="1269" alt="Screen Shot 2021-04-22 at 11 14 08 AM" src="https://user-images.githubusercontent.com/3227182/115740939-4cc1fe00-a35d-11eb-8f80-d31abc7d06c2.png">

User changes collection visibility to public:
<img width="1269" alt="Screen Shot 2021-04-22 at 11 14 21 AM" src="https://user-images.githubusercontent.com/3227182/115741259-93aff380-a35d-11eb-8bf6-6c6220314d59.png">

Admin deletes public collection:
<img width="1248" alt="Screen Shot 2021-04-22 at 11 15 00 AM" src="https://user-images.githubusercontent.com/3227182/115741038-6105fb00-a35d-11eb-8184-cd25ef7488a4.png">



## Related issues

https://github.com/usnistgov/WIPP/issues/28