### PR TITLE
feat: add local backend import option for new images collections

### DIFF
--- a/deploy/docker/config.json
+++ b/deploy/docker/config.json
@@ -3,5 +3,6 @@
   "jupyterNotebooksUrl": "JUPYTERHUB_URL",
   "plotsUiUrl": "VISIONUI_URL",
   "argoUiBaseUrl": "ARGOUIBASE_URL",
-  "catalogUiUrl": "CATALOGUI_URL"
+  "catalogUiUrl": "CATALOGUI_URL",
+  "displayLocalImportOption": "DISPLAY_LOCAL_IMPORT_OPTION"
 }

--- a/deploy/docker/entrypoint.sh
+++ b/deploy/docker/entrypoint.sh
@@ -19,13 +19,14 @@ sed -i \
     -e "s|@KEYCLOAK_URL_VALUE@|${KEYCLOAK_URL}|g" \
     /var/www/frontend/main.*.js
 
-# Update external tools URLs in frontend conf
+# Update external tools URLs and options in frontend conf
 sed -i \
   -e 's|TENSORBOARD_URL|'"${TENSORBOARD_URL}"'|' \
   -e 's|JUPYTERHUB_URL|'"${JUPYTERHUB_URL}"'|' \
   -e 's|VISIONUI_URL|'"${VISIONUI_URL}"'|' \
   -e 's|CATALOGUI_URL|'"${CATALOGUI_URL}"'|' \
   -e 's|ARGOUIBASE_URL|'"${ARGOUIBASE_URL}"'|' \
+  -e 's|DISPLAY_LOCAL_IMPORT_OPTION|'"${DISPLAY_LOCAL_IMPORT_OPTION}"'|' \
   /var/www/frontend/assets/config/config.json
 
 nginx -g 'daemon off;'

--- a/deploy/kubernetes/frontend-deployment.yaml
+++ b/deploy/kubernetes/frontend-deployment.yaml
@@ -26,6 +26,8 @@ spec:
           value: VISION_URL_VALUE
         - name: CATALOGUI_URL
           value: CATALOG_URL_VALUE
+        - name: DISPLAY_LOCAL_IMPORT_OPTION
+            value: DISPLAY_LOCAL_IMPORT_OPTION_VALUE
         ports:
         - containerPort: 80
       restartPolicy: Always

--- a/sample-config.json
+++ b/sample-config.json
@@ -3,5 +3,6 @@
   "tensorboardUrl": "/not-found",
   "jupyterNotebooksUrl": "/not-found",
   "plotsUiUrl": "/not-found",
-  "catalogUiUrl": "/not-found"
+  "catalogUiUrl": "/not-found",
+  "displayLocalImportOption": false
 }

--- a/src/app/images-collection/images-collection-detail/images-collection-detail.component.html
+++ b/src/app/images-collection/images-collection-detail/images-collection-detail.component.html
@@ -55,6 +55,9 @@
             <div *ngIf="!imagesCollection.importMethod || imagesCollection.importMethod == 'UPLOADED'">
               Uploaded
             </div>
+            <div *ngIf="imagesCollection.importMethod == 'BACKEND_IMPORT'">
+              Backend import from local folder
+            </div>
           </ng-template>
 
           <ng-template #catalogTipContent>Go to Catalog
@@ -158,7 +161,7 @@
     </div>
   </div>
 
-  <div *ngIf="!imagesCollection.locked">
+  <div *ngIf="!imagesCollection.locked && !(imagesCollection.importMethod=='BACKEND_IMPORT')">
     <h4>Upload Options</h4>
     <div class="row">
       <div class="col-md-9">

--- a/src/app/images-collection/images-collection-new/images-collection-new.component.css
+++ b/src/app/images-collection/images-collection-new/images-collection-new.component.css
@@ -1,0 +1,4 @@
+.options-radio-group {
+  display: flex;
+  flex-direction: column;
+}

--- a/src/app/images-collection/images-collection-new/images-collection-new.component.html
+++ b/src/app/images-collection/images-collection-new/images-collection-new.component.html
@@ -16,7 +16,31 @@
       <small class="form-text text-muted">Enter the collection name.</small>
     </div>
 
-    <mat-checkbox [(ngModel)]="usePattern" name="false">Filter images upon upload using a filename pattern</mat-checkbox>
+    <div class="form-group">
+      <label for="importMethod">Import method</label>
+      <span style="color: #e32"> * </span>
+      <mat-radio-group
+        id="importMethod"
+        class="options-radio-group"
+        name="format"
+        [(ngModel)]="imagesCollection.importMethod">
+        <mat-radio-button [value]="ImagesCollectionImportMethod.UPLOADED">
+          Browser upload <span placement="right" ngbTooltip="Upload images via web browser">
+          <i class="fas fa-question-circle"></i></span>
+        </mat-radio-button>
+        <mat-radio-button *ngIf="displayLocalImportOption" [value]="ImagesCollectionImportMethod.BACKEND_IMPORT">
+          Backend import <i>(beta) </i> <span placement="right" ngbTooltip="Import images from a folder local to the server">
+          <i class="fas fa-question-circle"></i></span>
+        </mat-radio-button>
+        <input *ngIf="imagesCollection.importMethod==ImagesCollectionImportMethod.BACKEND_IMPORT" type="text"
+               class="form-control" [(ngModel)]="imagesCollection.sourceBackendImport" name="sourceBackendimport"
+               placeholder="Enter the name of the folder to import">
+      </mat-radio-group>
+    </div>
+
+    <mat-checkbox *ngIf="imagesCollection.importMethod==ImagesCollectionImportMethod.UPLOADED"
+                  [(ngModel)]="usePattern" name="false">Filter images upon upload using a filename pattern
+    </mat-checkbox>
     <span class="text-danger" *ngIf="!usePattern && imagesCollection.pattern">Warning: pattern is not empty, but this option is not checked</span>
 
     <div class="row" *ngIf="usePattern">

--- a/src/app/images-collection/images-collection-new/images-collection-new.component.ts
+++ b/src/app/images-collection/images-collection-new/images-collection-new.component.ts
@@ -1,6 +1,7 @@
 import {Component, Input, NgModule, OnInit} from '@angular/core';
 import {NgbActiveModal, NgbModal} from '@ng-bootstrap/ng-bootstrap';
-import {ImagesCollection} from '../images-collection';
+import {ImagesCollection, ImagesCollectionImportMethod} from '../images-collection';
+import {AppConfigService} from '../../app-config.service';
 
 @Component({
   selector: 'app-images-collection-new',
@@ -12,9 +13,17 @@ export class ImagesCollectionNewComponent implements OnInit {
   @Input() modalReference: any;
   imagesCollection: ImagesCollection = new ImagesCollection();
   usePattern = false;
-  constructor(private activeModal: NgbActiveModal) { }
+  ImagesCollectionImportMethod = ImagesCollectionImportMethod;
+  displayLocalImportOption = false;
+
+  constructor(private activeModal: NgbActiveModal, private appConfigService: AppConfigService) {
+    if (this.appConfigService.getConfig().displayLocalImportOption) {
+      this.displayLocalImportOption = true;
+    }
+  }
 
   ngOnInit() {
+    this.imagesCollection.importMethod = ImagesCollectionImportMethod.UPLOADED;
   }
   cancel() {
     this.modalReference.dismiss();

--- a/src/app/images-collection/images-collection.module.ts
+++ b/src/app/images-collection/images-collection.module.ts
@@ -11,7 +11,7 @@ import {
   MatSortModule,
   MatTableModule,
   MatCheckboxModule,
-  MatLabel, MatFormFieldModule, MatInputModule
+  MatLabel, MatFormFieldModule, MatInputModule, MatRadioModule
 } from '@angular/material';
 import { ImagesCollectionNewComponent } from './images-collection-new/images-collection-new.component';
 import {FormsModule, ReactiveFormsModule} from '@angular/forms';
@@ -33,6 +33,7 @@ import {
     FormsModule,
     MatFormFieldModule,
     MatInputModule,
+    MatRadioModule,
     ReactiveFormsModule,
     InlineEditorModule,
     MatCheckboxModule

--- a/src/app/images-collection/images-collection.ts
+++ b/src/app/images-collection/images-collection.ts
@@ -4,7 +4,8 @@ export class ImagesCollection {
   creationDate: Date;
   sourceJob: string;
   sourceCatalog: string;
-  importMethod: string;
+  sourceBackendImport: string;
+  importMethod: ImagesCollectionImportMethod;
   locked: boolean;
   numberOfImages: number;
   imagesTotalSize: number;
@@ -23,4 +24,11 @@ export interface PaginatedImagesCollections {
   page: any;
   data: ImagesCollection[];
   _links: any;
+}
+
+export enum ImagesCollectionImportMethod {
+  UPLOADED,
+  JOB,
+  CATALOG,
+  BACKEND_IMPORT
 }


### PR DESCRIPTION
<!--
Please fill in the following template, and make sure your are following the contributing guidelines before submitting this PR
-->

## What does this PR do?

Add option to import images from a local folder when creating a new images collection.

Disabled by default, to turn option on set `displayLocalImportOption` to `true` in `config.json`

## Related PR

https://github.com/usnistgov/WIPP-backend/pull/193